### PR TITLE
Prevent errors with unknown weather condition

### DIFF
--- a/weather/weather.widget/index.coffee
+++ b/weather/weather.widget/index.coffee
@@ -149,7 +149,7 @@ iconMapping:
   "unknown"             :"&#xfo3e;"
 
 getIcon: (data) ->
-  @iconMapping['unknown'] if not data
+  return @iconMapping['unknown'] if not data
   if data.icon.indexOf('cloudy') > -1
     if data.cloudCover < 0.25
       @iconMapping["clear-day"]


### PR DESCRIPTION
Just added a default icon if the response returns a weather condition that isn't supported for some reason.
