### PR TITLE
Trimming command

### DIFF
--- a/top-cpu/top-cpu.widget/index.coffee
+++ b/top-cpu/top-cpu.widget/index.coffee
@@ -1,4 +1,4 @@
-command: "ps axro \"%cpu,ucomm,pid\" | sed -e 's/^[ \\t]*//g' -e 's/\\([0-9][0-9]*\\.[0-9][0-9]*\\)\\ /\\1\\%\\,/g' -e 's/\\ \\ *\\([0-9][0-9]*$\\)/\\,\\1/g' -e's/\\ \\ */\\_/g' | awk 'FNR>1' | head -n 3 | awk -F',' '{ printf \"%s,%s,%d\\n\", $1, $2, $3}' | sed -e 's/\\_/\\ /g'"
+command: "ps axro \"%cpu,ucomm,pid\" | awk 'FNR>1' | head -n 3 | sed -e 's/^[ ]*\\([0-9][0-9]*\\.[0-9][0-9]*\\)\\ /\\1\\%\\,/g' -e 's/\\ \\ *\\([0-9][0-9]*$\\)/\\,\\1/g'"
 
 refreshFrequency: 2000
 


### PR DESCRIPTION
Hey Felix, I did my best at slimming down the command. I could trim out a bunch more, but I haven't been able to figure out how to combine -e (script; multiple sed scripts strung together) with -r (extended regex; allows for '+' to symbolize 'one or more'... instead of [0-9][0-9]\* we could just use [0-9]+). I also read that -r is not portable, so I was a bit worried that might cause issues on certain machines.

Here is some notes about regex-extended from this [source](https://www.gnu.org/software/sed/manual/sed.html#index-g_t_0040acronym_007bGNU_007d-extensions_002c-extended-regular-expressions-33):

`-r
--regexp-extended
Use extended regular expressions rather than basic regular expressions. Extended regexps are those that egrep accepts; they can be clearer because they usually have less backslashes, but are a GNU extension and hence scripts that use them are not portable. See Extended regular expressions.`
