### PR TITLE
Added monday-first weeks option at calendar

### DIFF
--- a/calendar/calendar.widget/index.coffee
+++ b/calendar/calendar.widget/index.coffee
@@ -1,4 +1,11 @@
-command: 'cal && date'
+sundayFirstCalendar = 'cal && date'
+
+mondayFirstCalendar =  'cal | awk \'{ print " "$0; getline; print "Mo Tu We Th Fr Sa Su"; \
+getline; if (substr($0,1,2) == " 1") print "                    1 "; \
+do { prevline=$0; if (getline == 0) exit; print " " \
+substr(prevline,4,17) " " substr($0,1,2) " "; } while (1) }\' && date'
+
+command: sundayFirstCalendar
 
 refreshFrequency: 3600000
 


### PR DESCRIPTION
I've added an option to allow a different calendar layout, since Monday is the first day of week in some countries. The problem is that tricky command that I found at
http://apple.stackexchange.com/questions/93906/cal-command-start-monday

It's really awful but it seems to be the best choice since cal doesn't have any configuration setting to allow this.
