### PR TITLE
Update NetworkInfo to work with Thunderbolt Ethernet (Macbook Air and Retinas)

### DIFF
--- a/NetworkInfo/NetworkInfo.widget/NetworkInfo.sh
+++ b/NetworkInfo/NetworkInfo.widget/NetworkInfo.sh
@@ -27,6 +27,10 @@ startJSON
 # Output the Ethernet information.
 ip=$(networksetup -getinfo ethernet | grep -Ei '(^IP address:)' | awk '{print $3}')
 mac=$(networksetup -getinfo ethernet | grep -Ei '(^Ethernet address:)' | awk '{print $3}')
+if [ "$ip" = "" ];then 
+	ip=$(networksetup -getinfo thunderbolt\ ethernet | grep -Ei '(^IP address:)' | awk '{print $3}')
+	mac=$(networksetup -getinfo thunderbolt\ ethernet | grep -Ei '(^Ethernet address:)' | awk '{print $3}')
+fi
 exportService "ethernet"
 
 # Place a comma between services.


### PR DESCRIPTION
On retina MBPs, the ethernet is slightly different.  Here's the network services on my rMBP:

> networksetup -listallnetworkservices
An asterisk (*) denotes that a network service is disabled.
Thunderbolt Ethernet
Wi-Fi
Thunderbolt Bridge
VPN (PPTP)
Witopia KC IPsec
Bluetooth DUN
Bluetooth PAN
