### PR TITLE
Use correct service name for Thunderbolt Ethernet

### DIFF
--- a/NetworkInfo/NetworkInfo.widget/NetworkInfo.sh
+++ b/NetworkInfo/NetworkInfo.widget/NetworkInfo.sh
@@ -28,8 +28,14 @@ startJSON
 ip=$(networksetup -getinfo ethernet | grep -Ei '(^IP address:)' | awk '{print $3}')
 mac=$(networksetup -getinfo ethernet | grep -Ei '(^Ethernet address:)' | awk '{print $3}')
 if [ "$ip" = "" ];then 
-	ip=$(networksetup -getinfo thunderbolt\ ethernet | grep -Ei '(^IP address:)' | awk '{print $3}')
-	mac=$(networksetup -getinfo thunderbolt\ ethernet | grep -Ei '(^Ethernet address:)' | awk '{print $3}')
+    if networksetup -listallnetworkservices | grep -qEi '^Display Ethernet'; then
+        service="Display Ethernet"
+    else
+        service="Thunderbolt Ethernet"
+    fi
+
+    ip=$(networksetup -getinfo "$service" | grep -Ei '(^IP address:)' | awk '{print $3}')
+    mac=$(networksetup -getinfo "$service" | grep -Ei '(^Ethernet address:)' | awk '{print $3}')
 fi
 exportService "ethernet"
 


### PR DESCRIPTION
On my setup (Yosemite, Macbook Pro mid 2012, Thunderbolt Display from end 2013) the service is called *Display Ethernet* instead of *Thunderbolt Ethernet*. 

Updated the code to check for one of these two before getting the thunderbolt's information.

Follow-up to #97