### PR TITLE
Add ad check

### DIFF
--- a/Spotify-Current-Track/spotify-current-track.widget/index.coffee
+++ b/Spotify-Current-Track/spotify-current-track.widget/index.coffee
@@ -7,7 +7,12 @@ IFS='|' read -r theArtist theName <<<"$(osascript <<<'tell application "Spotify"
         set theName to name of theTrack
         return theArtist & "|" & theName
     end tell')" &&
-echo "$theArtist - $theName" || echo "Not Connected To Spotify"
+if [ -z "$theArtist" ]
+then
+    echo ""
+else
+    echo "$theArtist - $theName" || echo "Not Connected To Spotify"
+fi
 """
 
 refreshFrequency: 2000


### PR DESCRIPTION
Since all ads on Spotify don't have artist name, we can hide them.
Check if ad is playing. if yes, show nothing.