### PR TITLE
Fix leap year condition in index.coffee

### DIFF
--- a/calendar/index.coffee
+++ b/calendar/index.coffee
@@ -86,7 +86,7 @@ updateBody: (rows, table) ->
   year = today[2]
 
   lengths = [31, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30]
-  if year%4 == 0
+  if year%4 == 0 and (year%100 != 0 or year%400 == 0)
     lengths[2] = 29
 
   for week, i in rows


### PR DESCRIPTION
Leap years are divisible by 4 and and not 100, unless divisible by 400. One-line replacement to implement this, replacing check for division by 4.